### PR TITLE
Add style field to export CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.13.0",
   "description": "Simple menu elements for ProseMirror",
   "main": "dist/index.js",
+  "style": "style/menu.css",
   "license": "MIT",
   "maintainers": [
     {


### PR DESCRIPTION
This enables preprocessors that follow this convention (like the `postcss` family) to simply use:

```css
@import "prosemirror-menu";
```

and get the CSS, without having to monkey about looking inside the package to know the path.