### PR TITLE
allow spec.title to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The configuration object passed to the `MenuItem` constructor.
   wrapped in a drop-down or similar menu. The object
   should have a `label` property providing the text to display.
 
-* `title: ?string`\
+* `title: ?string | fn(state) → string)`\
   Defines DOM title (mouseover) text for the item.
 
 * `class: string`\

--- a/src/menu.js
+++ b/src/menu.js
@@ -39,7 +39,10 @@ class MenuItem {
       throw new RangeError("MenuItem without render, icon, or label property")
     }
 
-    if (spec.title) dom.setAttribute("title", translate(view, spec.title))
+    if (spec.title) {
+      const title=(typeof spec.title === "function" ? spec.title(view.state) : spec.title)
+      dom.setAttribute("title", translate(view, title))
+    }
     if (spec.class) dom.classList.add(spec.class)
     if (disabled) dom.classList.add(prefix + "-disabled")
     if (spec.css) dom.style.cssText += spec.css

--- a/src/menu.js
+++ b/src/menu.js
@@ -40,7 +40,7 @@ class MenuItem {
     }
 
     if (spec.title) {
-      const title=(typeof spec.title === "function" ? spec.title(view.state) : spec.title)
+      const title = (typeof spec.title === "function" ? spec.title(view.state) : spec.title)
       dom.setAttribute("title", translate(view, title))
     }
     if (spec.class) dom.classList.add(spec.class)


### PR DESCRIPTION
allow spec.title to be a function state => string

this allows different title on the same menu item depending on the context, for example an outdent icon which has different title if the current selection is in a list or not