### PR TITLE
Make menubar float work inside a scollable parent (not just window)

### DIFF
--- a/src/menubar.js
+++ b/src/menubar.js
@@ -103,7 +103,7 @@ class MenuBarView {
 
   updateFloat(scrollAncestor) {
     let parent = this.wrapper, editorRect = parent.getBoundingClientRect(),
-        top= scrollAncestor ? scrollAncestor.getBoundingClientRect().top : 0;
+        top= scrollAncestor ? Math.max(0, scrollAncestor.getBoundingClientRect().top) : 0;
 
     if (this.floating) {
       if (editorRect.top >= top || editorRect.bottom < this.menu.offsetHeight + 10) {

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -59,11 +59,12 @@ class MenuBarView {
       let scrollAncestor = findWrappingScollContainer(this.wrapper);
       this.scrollFunc = () => {
         let root = this.editorView.root
-        if (!(root.body || root).contains(this.wrapper))
-          window.removeEventListener("scroll", this.scrollFunc)
-          if (scrollAncestor) scrollAncestor.removeEventListener("scroll", this.scrollfunc)
-        else
-          this.updateFloat(scrollAncestor)
+        if (!(root.body || root).contains(this.wrapper)) {
+            window.removeEventListener("scroll", this.scrollFunc)
+            if (scrollAncestor) scrollAncestor.removeEventListener("scroll", this.scrollfunc)
+        } else {
+            this.updateFloat(scrollAncestor)
+        }
       }
       window.addEventListener("scroll", this.scrollFunc)
       if (scrollAncestor) scrollAncestor.addEventListener("scroll", this.scrollFunc)

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -60,7 +60,7 @@ class MenuBarView {
       this.scrollFunc = (e) => {
         let root = this.editorView.root
         if (!(root.body || root).contains(this.wrapper)) {
-            potentialScrollers.forEach(el => el.removeEventListener(this.scrollFunc()))
+            potentialScrollers.forEach(el => el.removeEventListener(this.scrollFunc))
         } else {
             this.updateFloat(e.target.getBoundingClientRect && e.target)
         }

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -147,14 +147,6 @@ function findWrappingScrollable(node) {
     if (cur.scrollHeight > cur.clientHeight) return cur
 }
 
-function parentsWhoCOuldScroll(node) {
-  let res = [];
-  for (let cur = node.parentNode; cur; cur = cur.parentNode)
-    res.push(cur);
-  res.push(window);
-  return res;
-}
-
 function findEverythingThatCouldScroll(node) {
     let res = [window];
     for (let cur = node.parentNode; cur; cur = cur.parentNode)

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -66,7 +66,7 @@ class MenuBarView {
           this.updateFloat(scrollAncestor)
       }
       window.addEventListener("scroll", this.scrollFunc)
-      if (scrollAncestor) scrollAncestor.addListener("scroll", this.scrollFunc)
+      if (scrollAncestor) scrollAncestor.addEventListener("scroll", this.scrollFunc)
     }
   }
 

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -56,7 +56,7 @@ class MenuBarView {
 
     if (options.floating && !isIOS()) {
       this.updateFloat()
-      let potentialScrollers = findEverythingThatCouldScroll(this.wrapper)
+      let potentialScrollers = getAllWrapping(this.wrapper)
       this.scrollFunc = (e) => {
         let root = this.editorView.root
         if (!(root.body || root).contains(this.wrapper)) {
@@ -101,7 +101,7 @@ class MenuBarView {
 
   updateFloat(scrollAncestor) {
     let parent = this.wrapper, editorRect = parent.getBoundingClientRect(),
-        top= scrollAncestor ? Math.max(0, scrollAncestor.getBoundingClientRect().top) : 0
+        top = scrollAncestor ? Math.max(0, scrollAncestor.getBoundingClientRect().top) : 0
 
     if (this.floating) {
       if (editorRect.top >= top || editorRect.bottom < this.menu.offsetHeight + 10) {
@@ -114,7 +114,7 @@ class MenuBarView {
         let border = (parent.offsetWidth - parent.clientWidth) / 2
         this.menu.style.left = (editorRect.left + border) + "px"
         this.menu.style.display = (editorRect.top > window.innerHeight ? "none" : "")
-        if (scrollAncestor) this.menu.style.top=top + "px"
+        if (scrollAncestor) this.menu.style.top = top + "px"
       }
     } else {
       if (editorRect.top < top && editorRect.bottom >= this.menu.offsetHeight + 10) {
@@ -147,7 +147,7 @@ function findWrappingScrollable(node) {
     if (cur.scrollHeight > cur.clientHeight) return cur
 }
 
-function findEverythingThatCouldScroll(node) {
+function getAllWrapping(node) {
     let res = [window]
     for (let cur = node.parentNode; cur; cur = cur.parentNode)
         res.push(cur)

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -56,7 +56,7 @@ class MenuBarView {
 
     if (options.floating && !isIOS()) {
       this.updateFloat()
-      let potentialScrollers = findEverythingThatCouldScroll(this.wrapper);
+      let potentialScrollers = findEverythingThatCouldScroll(this.wrapper)
       this.scrollFunc = (e) => {
         let root = this.editorView.root
         if (!(root.body || root).contains(this.wrapper)) {
@@ -101,7 +101,7 @@ class MenuBarView {
 
   updateFloat(scrollAncestor) {
     let parent = this.wrapper, editorRect = parent.getBoundingClientRect(),
-        top= scrollAncestor ? Math.max(0, scrollAncestor.getBoundingClientRect().top) : 0;
+        top= scrollAncestor ? Math.max(0, scrollAncestor.getBoundingClientRect().top) : 0
 
     if (this.floating) {
       if (editorRect.top >= top || editorRect.bottom < this.menu.offsetHeight + 10) {
@@ -148,8 +148,8 @@ function findWrappingScrollable(node) {
 }
 
 function findEverythingThatCouldScroll(node) {
-    let res = [window];
+    let res = [window]
     for (let cur = node.parentNode; cur; cur = cur.parentNode)
         res.push(cur)
-    return res;
+    return res
 }

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -61,7 +61,7 @@ class MenuBarView {
         let root = this.editorView.root
         if (!(root.body || root).contains(this.wrapper))
           window.removeEventListener("scroll", this.scrollFunc)
-          if (scrollAncestor) scrollAncestor.removeListener("scroll", this.scrollfunc)
+          if (scrollAncestor) scrollAncestor.removeEventListener("scroll", this.scrollfunc)
         else
           this.updateFloat(scrollAncestor)
       }

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -56,18 +56,16 @@ class MenuBarView {
 
     if (options.floating && !isIOS()) {
       this.updateFloat()
-      let scrollAncestor = findWrappingScollContainer(this.wrapper);
-      this.scrollFunc = () => {
+      let potentialScrollers = findEverythingThatCouldScroll(this.wrapper);
+      this.scrollFunc = (e) => {
         let root = this.editorView.root
         if (!(root.body || root).contains(this.wrapper)) {
-            window.removeEventListener("scroll", this.scrollFunc)
-            if (scrollAncestor) scrollAncestor.removeEventListener("scroll", this.scrollfunc)
+            potentialScrollers.forEach(el => el.removeEventListener(this.scrollFunc()))
         } else {
-            this.updateFloat(scrollAncestor)
+            this.updateFloat(e.target.getBoundingClientRect && e.target)
         }
       }
-      window.addEventListener("scroll", this.scrollFunc)
-      if (scrollAncestor) scrollAncestor.addEventListener("scroll", this.scrollFunc)
+      potentialScrollers.forEach(el => el.addEventListener('scroll', this.scrollFunc))
     }
   }
 
@@ -149,10 +147,17 @@ function findWrappingScrollable(node) {
     if (cur.scrollHeight > cur.clientHeight) return cur
 }
 
-function findWrappingScollContainer(node) {
-    for (let cur = node.parentNode; cur; cur = cur.parentNode) {
-        if (cur.scrollHeight > cur.clientHeight && cur.parentNode && cur.scrollHeight > cur.parentNode.scrollHeight) {
-            return cur;
-        }
-    }
+function parentsWhoCOuldScroll(node) {
+  let res = [];
+  for (let cur = node.parentNode; cur; cur = cur.parentNode)
+    res.push(cur);
+  res.push(window);
+  return res;
+}
+
+function findEverythingThatCouldScroll(node) {
+    let res = [window];
+    for (let cur = node.parentNode; cur; cur = cur.parentNode)
+        res.push(cur)
+    return res;
 }


### PR DESCRIPTION
Say you put a prosemirror editor with a menubar inside of a scrollable div, and you still want that nice float + sticky behaviour.

Before, we wouldn't even catch the scroll events (they don't get fired on window.) With this change, we look for cases where we are in a scrollable element, catch those events too, and detect + float to the appropriate top location.

This is my first PR here, so I apologize in advance if I've made any faux pas.
