### PR TITLE
Delete redundant css rule

### DIFF
--- a/style/menu.css
+++ b/style/menu.css
@@ -102,11 +102,6 @@
   border-radius: 4px;
 }
 
-.ProseMirror-menu-active {
-  background: #eee;
-  border-radius: 4px;
-}
-
 .ProseMirror-menu-disabled {
   opacity: .3;
 }


### PR DESCRIPTION
For some reason the style for `.ProseMirror-menu-active` is duplicated in the [`menu.css`](https://github.com/ProseMirror/prosemirror-menu/blob/e289fa1280da2b9c602c1a1694fbda947d39bf7b/style/menu.css#L100-L108) file. This request deletes the redundant part.