### PR TITLE
Improve ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "prosemirror-history": "^1.0.0"
   },
   "devDependencies": {
-    "rollup": "^0.49.0",
-    "rollup-plugin-buble": "^0.15.0"
+    "rollup": "^1.26.3",
+    "@rollup/plugin-buble": "^0.20.0"
   },
   "scripts": {
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/prosemirror/prosemirror-menu.git"
   },
   "dependencies": {
-    "crel": "^3.0.0",
+    "crel-esm": "^4.0.1",
     "prosemirror-state": "^1.0.0",
     "prosemirror-commands": "^1.0.0",
     "prosemirror-history": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "Simple menu elements for ProseMirror",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "style": "style/menu.css",
   "license": "MIT",
   "maintainers": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/prosemirror/prosemirror-menu.git"
   },
   "dependencies": {
-    "crel-esm": "^4.0.1",
+    "crel": "^3.0.0",
     "prosemirror-state": "^1.0.0",
     "prosemirror-commands": "^1.0.0",
     "prosemirror-history": "^1.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,12 @@
-module.exports = {
-  input: "./src/index.js",
-  output: {format: "cjs", file: "dist/index.js"},
-  sourcemap: true,
-  plugins: [require("rollup-plugin-buble")()],
+import buble from '@rollup/plugin-buble'
+
+export default {
+  input: './src/index.js',
+  output: {
+    dir: 'dist',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [buble()],
   external(id) { return !/^[\.\/]/.test(id) }
 }


### PR DESCRIPTION
The latest version of crel (4.0.1) looks backward compatible. It is also written using ES6 features. Unfortunately, it does not make use of ESM exports.

I submitted a PR but got not answers:
https://github.com/KoryNunn/crel/pull/51

In the meantime, I have forked the repository:
https://github.com/prosemirror-esm/crel/tree/crel-esm

and published it on npmjs.

I suggest using this version until official support is provided. 