### PR TITLE
Update crel to v4.2.0, which supports IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/prosemirror/prosemirror-menu.git"
   },
   "dependencies": {
-    "crel": "^3.1.0",
+    "crel": "^4.2.0",
     "prosemirror-state": "^1.0.0",
     "prosemirror-commands": "^1.0.0",
     "prosemirror-history": "^1.0.0"


### PR DESCRIPTION
ref: 71e13c5e10a3284afe12a9ac3e520fd566a01724
https://github.com/ProseMirror/prosemirror/issues/1009
https://github.com/KoryNunn/crel/pull/55

crel v4.1.0 does not works well with IE11, but crel v4.2.0 works by https://github.com/KoryNunn/crel/pull/55.

So we can update the dependency.
