### PR TITLE
Mark EditorView and dom.Event as optional in run()

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -68,7 +68,7 @@ function translate(view, text) {
 // MenuItemSpec:: interface
 // The configuration object passed to the `MenuItem` constructor.
 //
-//   run:: (EditorState, (Transaction), EditorView, dom.Event)
+//   run:: (EditorState, (Transaction), ?EditorView, ?dom.Event)
 //   The function to execute when the menu item is activated.
 //
 //   select:: ?(EditorState) → bool


### PR DESCRIPTION
I believe these are optional.

https://github.com/ProseMirror/prosemirror-commands/blob/3126d5c625953ba590c5d3a0db7f1009f46f1571/src/commands.js#L174-L193

https://github.com/ProseMirror/prosemirror-menu/blob/9d68b3b75511e9815b2433263329fb2d344e0be8/src/menu.js#L370-L377