### PR TITLE
[doc] Make non-nullable renderGrouped's returned `dom`

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -272,7 +272,7 @@ export class DropdownSubmenu {
   }
 }
 
-// :: (EditorView, [union<MenuElement, [MenuElement]>]) → {dom: ?dom.DocumentFragment, update: (EditorState) → bool}
+// :: (EditorView, [union<MenuElement, [MenuElement]>]) → {dom: dom.DocumentFragment, update: (EditorState) → bool}
 // Render the given, possibly nested, array of menu elements into a
 // document fragment, placing separators between them (and ensuring no
 // superfluous separators appear when some of the groups turn out to


### PR DESCRIPTION
Actually `dom` of renderGrouped's returned value is always non-null because the `result` variable is initialized with `document.createDocumentFragment()` and `result` is the `dom`.
However, the documentation says it is nullable.

This patch fixes the documentation.