### PR TITLE
Fix renderGroup type document

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -272,7 +272,7 @@ export class DropdownSubmenu {
   }
 }
 
-// :: (EditorView, [union<MenuElement, [MenuElement]>]) → {dom: dom.DocumentFragment, update: (EditorState) → bool}
+// :: (EditorView, [[MenuElement]]) → {dom: dom.DocumentFragment, update: (EditorState) → bool}
 // Render the given, possibly nested, array of menu elements into a
 // document fragment, placing separators between them (and ensuring no
 // superfluous separators appear when some of the groups turn out to


### PR DESCRIPTION
This PR updates `renderGroup` type document to match it to the implementation.


The type doc says it receives `[[MenuElement]]` or `[MenuElement]`, but actually it receives only `[[MenuElement]]`.
I tried to pass `[MenuElement]` to the method, then it ignored the elements. It means it didn't display anything in the menubar.

By the way, `menuBar` function's type doc, which uses `renderGroup`, says it only receives `[[MenuElement]]`.
https://github.com/ProseMirror/prosemirror-menu/blob/0fe040dc837d240237a79dc549a29020aaba2db0/src/menubar.js#L21



----



If it is an implementation bug, feel free to close this PR.