### PR TITLE
Improve accessibility

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -13,9 +13,9 @@ function hashPath(path: string) {
 export function getIcon(
   root: Document | ShadowRoot,
   icon: {path: string, width: number, height: number} | {text: string, css?: string} | {dom: Node}
-): HTMLElement {
+): HTMLButtonElement {
   let doc = (root.nodeType == 9 ? root as Document : root.ownerDocument) || document
-  let node = doc.createElement("div")
+  let node = doc.createElement("button")
   node.className = prefix
   if ((icon as any).path) {
     let {path, width, height} = icon as {path: string, width: number, height: number}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -613,7 +613,7 @@ export function renderGrouped(view: EditorView, content: readonly (readonly Menu
 }
 
 function separator() {
-  return crel("span", {class: prefix + "separator"})
+  return crel("span", {class: prefix + "separator", role: "separator"})
 }
 
 /// A set of basic editor-related icons. Contains the properties

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -59,6 +59,10 @@ export class MenuItem<E extends HTMLElement = HTMLButtonElement> implements Menu
       e.preventDefault()
       if (!dom!.classList.contains(prefix + "-disabled"))
         spec.run(view.state, view.dispatch, view, e)
+      // mouse users want the focus restored to the editor
+      let clicks = (e as MouseEvent).detail
+      if (typeof clicks === "number" && clicks > 0)
+        setTimeout(() => view.dom.focus(), 0)
     })
 
     function update(state: EditorState) {
@@ -275,6 +279,10 @@ export class Dropdown implements MenuElement {
           }
         })
       }
+      // mouse users want the focus restored to the editor
+      let clicks = e.detail
+      if (typeof clicks === "number" && clicks > 0)
+        setTimeout(() => view.dom.focus(), 0)
     })
 
     function update(state: EditorState) {
@@ -473,6 +481,11 @@ export class DropdownSubmenu implements MenuElement {
             listeningOnClose = null
           }
         })
+
+      // mouse users want the focus restored to the editor
+      let clicks = (e as MouseEvent).detail
+      if (typeof clicks === "number" && clicks > 0)
+        setTimeout(() => view.dom.focus(), 0)
     }
 
     btn.addEventListener("click", openSubmenu)

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -67,12 +67,12 @@ export class MenuItem<E extends HTMLElement = HTMLButtonElement> implements Menu
       if (spec.enable) {
         enabled = spec.enable(state) || false
         setClass(dom!, prefix + "-disabled", !enabled)
-        dom!.setAttribute("aria-disabled", (!enabled).toString());
+        dom!.setAttribute("aria-disabled", (!enabled).toString())
       }
       if (spec.active) {
         let active = enabled && spec.active(state) || false
         setClass(dom!, prefix + "-active", active)
-        dom!.setAttribute("aria-pressed", active.toString());
+        dom!.setAttribute("aria-pressed", active.toString())
       }
       return true
     }
@@ -179,7 +179,7 @@ export class Dropdown implements MenuElement {
       css?: string
 
       /// When true, renders the contents of the dropdown in an `<ol>` element, instead of the default `<ul>` element.
-      ordered?: boolean;
+      ordered?: boolean
     } = {}) {
     this.options = options || {}
     this.content = Array.isArray(content) ? content : [content]
@@ -244,9 +244,9 @@ export class Dropdown implements MenuElement {
 function renderDropdownItems(items: readonly MenuElement[], view: EditorView, ordered: boolean = false) {
   let result = document.createDocumentFragment(), updates: ((state: EditorState) => boolean)[] = []
   for (let i = 0; i < items.length; i++) {
-    let item = items[i];
+    let item = items[i]
     let {dom, update} = item.render(view)
-    const checked = item.active ? item.active(view.state) : false;
+    const checked = item.active ? item.active(view.state) : false
     result.appendChild(
       crel(
         "li",
@@ -257,27 +257,27 @@ function renderDropdownItems(items: readonly MenuElement[], view: EditorView, or
         },
         dom,
       ),
-    );
+    )
     updates.push(update)
   }
 
   function update(state: EditorState) {
-    let something = false;
+    let something = false
     for (let i = 0; i < items.length; i++) {
       let item = items[i], dom = result.children[i] as HTMLElement, itemUpdate = updates[i]
-      const checked = item.active ? item.active(state) : false;
+      const checked = item.active ? item.active(state) : false
       if (dom.getAttribute("aria-checked") !== checked.toString()) {
-        dom.setAttribute("aria-checked", checked.toString());
-        something = true;
+        dom.setAttribute("aria-checked", checked.toString())
+        something = true
       }
       let up = itemUpdate(state)
       dom.style.display = up ? "" : "none"
       if (up) something = true
     }
-    return something;
+    return something
   }
 
-  const dom = crel(ordered ? "ol" : "ul", { class: `${prefix}-dropdown-items`, role: "menu" }, result);
+  const dom = crel(ordered ? "ol" : "ul", { class: `${prefix}-dropdown-items`, role: "menu" }, result)
   return {dom, update}
 }
 

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -56,14 +56,11 @@ export class MenuItem<E extends HTMLElement = HTMLButtonElement> implements Menu
     if (spec.css) dom.style.cssText += spec.css
 
     dom.addEventListener("click", e => {
-      e.preventDefault()
       if (!dom!.classList.contains(prefix + "-disabled"))
         spec.run(view.state, view.dispatch, view, e)
-      // mouse users want the focus restored to the editor
-      let clicks = (e as MouseEvent).detail
-      if (typeof clicks === "number" && clicks > 0)
-        setTimeout(() => view.dom.focus(), 0)
     })
+    // Clicking on a menu item should not remove focus from the editor
+    dom.addEventListener("mousedown", e => e.preventDefault())
 
     function update(state: EditorState) {
       if (spec.select) {
@@ -233,7 +230,6 @@ export class Dropdown implements MenuElement {
       }
     }
     btn.addEventListener("click", e => {
-      e.preventDefault()
       markMenuEvent(e)
       if (open) {
         close()
@@ -279,11 +275,9 @@ export class Dropdown implements MenuElement {
           }
         })
       }
-      // mouse users want the focus restored to the editor
-      let clicks = e.detail
-      if (typeof clicks === "number" && clicks > 0)
-        setTimeout(() => view.dom.focus(), 0)
     })
+    // Clicking on a dropdown should not remove focus from the editor
+    btn.addEventListener("mousedown", e => e.preventDefault())
 
     function update(state: EditorState) {
       let inner = content.update(state)
@@ -479,11 +473,6 @@ export class DropdownSubmenu implements MenuElement {
             listeningOnClose = null
           }
         })
-
-      // mouse users want the focus restored to the editor
-      let clicks = (e as MouseEvent).detail
-      if (typeof clicks === "number" && clicks > 0)
-        setTimeout(() => view.dom.focus(), 0)
     }
 
     btn.addEventListener("click", openSubmenu)
@@ -492,6 +481,8 @@ export class DropdownSubmenu implements MenuElement {
         openSubmenu(e)
       }
     })
+    // Clicking on an item should not remove focus from the editor
+    btn.addEventListener("mousedown", e => e.preventDefault())
 
     items.dom.addEventListener("keydown", (event) => {
       markMenuEvent(event)

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -271,6 +271,7 @@ export class Dropdown implements MenuElement {
           } else if (event.key === "Escape") {
             event.preventDefault()
             close()
+            btn.focus()
           }
         })
       }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -239,6 +239,9 @@ export class Dropdown implements MenuElement {
           if (!isMenuEvent(wrap)) close()
         })
 
+        // If triggered using the keyboard, move focus to first item
+        if (e.detail === 0) this.focusables[0].focus()
+
         const orientation = this.options.orientation || "vertical"
         const nextFocusKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight"
         const prevFocusKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft"
@@ -305,7 +308,6 @@ export class Dropdown implements MenuElement {
     dom.appendChild(menuDOM)
     trigger.ariaControlsElements = [items]
     trigger.setAttribute("aria-expanded", "true")
-    this.focusables[0].focus()
     return {close, node: menuDOM}
   }
 
@@ -464,7 +466,6 @@ export class DropdownSubmenu implements MenuElement {
       e.stopPropagation()
       markMenuEvent(e)
       setClass(wrap, prefix + "-submenu-wrap-active", true)
-      items.focusables[0].focus()
       if (!listeningOnClose)
         win.addEventListener("click", listeningOnClose = () => {
           if (!isMenuEvent(wrap)) {
@@ -479,6 +480,7 @@ export class DropdownSubmenu implements MenuElement {
     btn.addEventListener("keydown", e => {
       if (e.key === enterSubmenuKey) {
         openSubmenu(e)
+        items.focusables[0].focus()
       }
     })
     // Clicking on an item should not remove focus from the editor

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -398,12 +398,10 @@ function renderDropdownItems(
 
   const dom = crel(
     options.ordered ? "ol" : "ul",
-    {
-      role: "menu",
-      "aria-orientation": options.orientation || "vertical"
-    },
+    { role: "menu" },
     result
   )
+  if (options.orientation) dom.ariaOrientation = options.orientation
   return {dom, update, focusables}
 }
 

--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -21,11 +21,11 @@ export function menuBar(options: {
 
   /// For accessibility purposes, specify if the menu is displayed
   /// horizontally or vertically. The default is "horizontal".
-  orientation?: "horizontal" | "vertical";
+  orientation?: "horizontal" | "vertical"
 
   /// Determines whether the menu is placed before or after the editor in the DOM.
   /// The default is "before".
-  position?: "before" | "after";
+  position?: "before" | "after"
 
   /// Determines whether the menu floats, i.e. whether it sticks to
   /// the top of the viewport when the editor is partially scrolled
@@ -64,16 +64,15 @@ class MenuBarView {
     if (editorView.dom.parentNode)
       editorView.dom.parentNode.replaceChild(this.wrapper, editorView.dom)
     if (options.position === "after") {
-      this.wrapper.insertBefore(editorView.dom, this.wrapper.firstChild);
+      this.wrapper.insertBefore(editorView.dom, this.wrapper.firstChild)
     } else {
-      this.wrapper.appendChild(editorView.dom);
+      this.wrapper.appendChild(editorView.dom)
     }
 
     let {dom, update, focusables} = renderGrouped(this.editorView, this.options.content)
     this.contentUpdate = update
     this.focusables = focusables
     this.menu.appendChild(dom)
-    this.update()
 
     if (options.floating && !isIOS()) {
       this.updateFloat()
@@ -88,84 +87,84 @@ class MenuBarView {
       potentialScrollers.forEach(el => el.addEventListener('scroll', this.scrollHandler!))
     }
 
-
     // set `tabindex` to -1 for all but the first focusable item
     for (let i = 1; i < focusables.length; i++) {
-      const focusable = focusables[i];
-      focusable.setAttribute("tabindex", "-1");
+      focusables[i].setAttribute("tabindex", "-1")
     }
 
     // update focusIndex on focus change
     for (let i = 0; i < focusables.length; i++) {
-      const focusable = focusables[i];
+      const focusable = focusables[i]
       focusable.addEventListener("focus", () => {
-        if (this.focusIndex === i) return;
-        const prevFocusItem = this.focusables[this.focusIndex];
-        prevFocusItem.setAttribute("tabindex", "-1");
-        focusable.setAttribute("tabindex", "0");
-        this.focusIndex = i;
-      });
+        if (this.focusIndex === i) return
+        const prevFocusItem = this.focusables[this.focusIndex]
+        prevFocusItem.setAttribute("tabindex", "-1")
+        focusable.setAttribute("tabindex", "0")
+        this.focusIndex = i
+      })
     }
 
-    const orientation = this.options.orientation || "horizontal";
-    const nextFocusKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight";
-    const prevFocusKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft";
+    const orientation = this.options.orientation || "horizontal"
+    const nextFocusKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight"
+    const prevFocusKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft"
 
     this.menu.addEventListener("keydown", (event) => {
       if (event.key === nextFocusKey) {
-        event.preventDefault();
-        this.setFocusToNext();
+        event.preventDefault()
+        this.setFocusToNext()
       } else if (event.key === prevFocusKey) {
-        event.preventDefault();
-        this.setFocusToPrev();
+        event.preventDefault()
+        this.setFocusToPrev()
       } else if (event.key === "Home") {
-        event.preventDefault();
-        this.setFocusToFirst();
+        event.preventDefault()
+        this.setFocusToFirst()
       } else if (event.key === "End") {
-        event.preventDefault();
-        this.setFocusToLast();
+        event.preventDefault()
+        this.setFocusToLast()
       }
-    });
+    })
+
+    this.update()
   }
 
   setFocusToNext() {
-    if (this.focusables.length <= 1) return;
-    const currentFocusItem = this.focusables[this.focusIndex];
-    currentFocusItem.setAttribute("tabindex", "-1");
-    this.focusIndex = (this.focusIndex + 1) % this.focusables.length;
-    const nextFocusItem = this.focusables[this.focusIndex];
-    nextFocusItem.setAttribute("tabindex", "0");
-    nextFocusItem.focus();
+    if (this.focusables.length <= 1) return
+    const currentFocusItem = this.focusables[this.focusIndex]
+    currentFocusItem.setAttribute("tabindex", "-1")
+    this.focusIndex = (this.focusIndex + 1) % this.focusables.length
+    const nextFocusItem = this.focusables[this.focusIndex]
+    nextFocusItem.setAttribute("tabindex", "0")
+    nextFocusItem.focus()
   }
 
   setFocusToPrev() {
-    if (this.focusables.length <= 1) return;
-    const currentFocusItem = this.focusables[this.focusIndex];
-    currentFocusItem.setAttribute("tabindex", "-1");
-    this.focusIndex = (this.focusIndex - 1 + this.focusables.length) % this.focusables.length;
-    const prevFocusItem = this.focusables[this.focusIndex];
-    prevFocusItem.setAttribute("tabindex", "0");
-    prevFocusItem.focus();
+    if (this.focusables.length <= 1) return
+    const currentFocusItem = this.focusables[this.focusIndex]
+    currentFocusItem.setAttribute("tabindex", "-1")
+    this.focusIndex = (this.focusIndex - 1 + this.focusables.length) % this.focusables.length
+    const prevFocusItem = this.focusables[this.focusIndex]
+    prevFocusItem.setAttribute("tabindex", "0")
+    prevFocusItem.focus()
   }
 
   setFocusToFirst() {
-    if (this.focusables.length === 0) return;
-    const currentFocusItem = this.focusables[this.focusIndex];
-    currentFocusItem.setAttribute("tabindex", "-1");
-    this.focusIndex = 0;
-    const firstFocusItem = this.focusables[0];
-    firstFocusItem.setAttribute("tabindex", "0");
-    firstFocusItem.focus();
+    if (this.focusables.length === 0) return
+    const currentFocusItem = this.focusables[this.focusIndex]
+    currentFocusItem.setAttribute("tabindex", "-1")
+    this.focusIndex = 0
+    const firstFocusItem = this.focusables[0]
+    firstFocusItem.setAttribute("tabindex", "0")
+    firstFocusItem.focus()
   }
 
   setFocusToLast() {
-    if (this.focusables.length === 0) return;
-    const currentFocusItem = this.focusables[this.focusIndex];
-    currentFocusItem.setAttribute("tabindex", "-1");
-    this.focusIndex = this.focusables.length - 1;
-    const lastFocusItem = this.focusables[this.focusIndex];
-    lastFocusItem.setAttribute("tabindex", "0");
-    lastFocusItem.focus();
+    if (this.focusables.length === 0) return
+    const currentFocusItem = this.focusables[this.focusIndex]
+    currentFocusItem.setAttribute("tabindex", "-1")
+    this.focusIndex = this.focusables.length - 1
+    const lastFocusItem = this.focusables[this.focusIndex]
+    lastFocusItem.setAttribute("tabindex", "0")
+    lastFocusItem.focus()
   }
 
   update() {

--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -12,6 +12,12 @@ function isIOS() {
   return !/Edge\/\d/.test(agent) && /AppleWebKit/.test(agent) && /Mobile\/\w+/.test(agent)
 }
 
+function flatten<T>(arr: readonly(readonly T[])[]): readonly T[] {
+  return arr.reduce(function (flat, item) {
+    return flat.concat(item)
+  }, [])
+}
+
 /// A plugin that will place a menu bar above the editor. Note that
 /// this involves wrapping the editor in an additional `<div>`.
 export function menuBar(options: {
@@ -110,61 +116,66 @@ class MenuBarView {
 
     this.menu.addEventListener("keydown", (event) => {
       if (event.key === nextFocusKey) {
-        event.preventDefault()
-        this.setFocusToNext()
+        const nextIndex = this.makeContentIndexMover(this.focusIndex, 1)(editorView.state)
+        if (typeof nextIndex === "number") {
+          event.preventDefault()
+          this.setFocusToIndex(nextIndex)
+        }
       } else if (event.key === prevFocusKey) {
-        event.preventDefault()
-        this.setFocusToPrev()
+        const prevIndex = this.makeContentIndexMover(this.focusIndex, -1)(editorView.state)
+        if (typeof prevIndex === "number") {
+          event.preventDefault()
+          this.setFocusToIndex(prevIndex)
+        }
       } else if (event.key === "Home") {
-        event.preventDefault()
-        this.setFocusToFirst()
+        const startIndex = this.makeContentIndexMover(-1, 1)(editorView.state)
+        if (typeof startIndex === "number") {
+          event.preventDefault()
+          this.setFocusToIndex(startIndex)
+        }
       } else if (event.key === "End") {
-        event.preventDefault()
-        this.setFocusToLast()
+        const endIndex = this.makeContentIndexMover(this.focusables.length, -1)(editorView.state)
+        if (typeof endIndex === "number") {
+          event.preventDefault()
+          this.setFocusToIndex(endIndex)
+        }
       }
     })
 
     this.update()
   }
 
-  setFocusToNext() {
+  setFocusToIndex(index: number) {
     if (this.focusables.length <= 1) return
+    if (index < 0 || index >= this.focusables.length)
+      throw new RangeError(`MenuBar focus index must be between 0 and ${this.focusables.length-1}, got ${index}`)
     const currentFocusItem = this.focusables[this.focusIndex]
     currentFocusItem.setAttribute("tabindex", "-1")
-    this.focusIndex = (this.focusIndex + 1) % this.focusables.length
-    const nextFocusItem = this.focusables[this.focusIndex]
+    const nextFocusItem = this.focusables[index]
     nextFocusItem.setAttribute("tabindex", "0")
+    this.focusIndex = index
     nextFocusItem.focus()
   }
 
-  setFocusToPrev() {
-    if (this.focusables.length <= 1) return
-    const currentFocusItem = this.focusables[this.focusIndex]
-    currentFocusItem.setAttribute("tabindex", "-1")
-    this.focusIndex = (this.focusIndex - 1 + this.focusables.length) % this.focusables.length
-    const prevFocusItem = this.focusables[this.focusIndex]
-    prevFocusItem.setAttribute("tabindex", "0")
-    prevFocusItem.focus()
-  }
-
-  setFocusToFirst() {
-    if (this.focusables.length === 0) return
-    const currentFocusItem = this.focusables[this.focusIndex]
-    currentFocusItem.setAttribute("tabindex", "-1")
-    this.focusIndex = 0
-    const firstFocusItem = this.focusables[0]
-    firstFocusItem.setAttribute("tabindex", "0")
-    firstFocusItem.focus()
-  }
-
-  setFocusToLast() {
-    if (this.focusables.length === 0) return
-    const currentFocusItem = this.focusables[this.focusIndex]
-    currentFocusItem.setAttribute("tabindex", "-1")
-    this.focusIndex = this.focusables.length - 1
-    const lastFocusItem = this.focusables[this.focusIndex]
-    lastFocusItem.setAttribute("tabindex", "0")
-    lastFocusItem.focus()
+  // Returns a function that moves an index through the flattened `this.options.content` array,
+  // skipping deselected items.
+  makeContentIndexMover(startIndex: number, delta: 1 | -1 = 1) {
+    const content = flatten(this.options.content), length = content.length
+    return function (state: EditorState): number | null {
+      let nextIndex = (startIndex + delta + length) % length
+      const firstTestedIndex = nextIndex
+      let spec = content[nextIndex]
+      let selected = spec.selected ? spec.selected(state) : true
+      while (!selected) {
+        nextIndex = (nextIndex + delta + length) % length
+        // If we have looped all the way around to the first tested index,
+        // we're not going to get a result (all content is deselected).
+        if (nextIndex === firstTestedIndex) return null
+        spec = content[nextIndex]
+        selected = spec.selected ? spec.selected(state) : true
+      }
+      return nextIndex;
+    }
   }
 
   update() {

--- a/style/menu.css
+++ b/style/menu.css
@@ -18,17 +18,24 @@
   display: inline-block;
 }
 
+.ProseMirror-menuitem button {
+  border: none;
+  background-image: none;
+  background-color: transparent;
+  box-shadow: none;
+}
+
 .ProseMirror-menuseparator {
   border-right: 1px solid #ddd;
   margin-right: 3px;
 }
 
-.ProseMirror-menu-dropdown, .ProseMirror-menu-dropdown-menu {
+.ProseMirror-menuitem .ProseMirror-menu-dropdown, .ProseMirror-menu-dropdown-menu {
   font-size: 90%;
   white-space: nowrap;
 }
 
-.ProseMirror-menu-dropdown {
+.ProseMirror-menuitem .ProseMirror-menu-dropdown {
   vertical-align: 1px;
   cursor: pointer;
   position: relative;
@@ -60,17 +67,27 @@
   padding: 2px;
 }
 
+.ProseMirror-menu-dropdown-menu ul,
+.ProseMirror-menu-dropdown-menu ol,
+.ProseMirror-menu-submenu ul,
+.ProseMirror-menu-submenu ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .ProseMirror-menu-dropdown-menu {
   z-index: 15;
   min-width: 6em;
 }
 
-.ProseMirror-menu-dropdown-item {
+.ProseMirror-menu-dropdown-item button {
   cursor: pointer;
   padding: 2px 8px 2px 4px;
 }
 
-.ProseMirror-menu-dropdown-item:hover {
+.ProseMirror-menu-dropdown-item:hover,
+.ProseMirror-menu-dropdown-item:focus-within {
   background: #f2f2f2;
 }
 
@@ -97,12 +114,12 @@
   top: -3px;
 }
 
-.ProseMirror-menu-active {
+.ProseMirror-menuitem .ProseMirror-menu-active {
   background: #eee;
   border-radius: 4px;
 }
 
-.ProseMirror-menu-disabled {
+.ProseMirror-menuitem .ProseMirror-menu-disabled {
   opacity: .3;
 }
 

--- a/style/menu.css
+++ b/style/menu.css
@@ -106,7 +106,9 @@
   opacity: .3;
 }
 
-.ProseMirror-menu-submenu-wrap:hover .ProseMirror-menu-submenu, .ProseMirror-menu-submenu-wrap-active .ProseMirror-menu-submenu {
+.ProseMirror-menu-submenu-wrap:hover .ProseMirror-menu-submenu,
+.ProseMirror-menu-submenu:focus-within,
+.ProseMirror-menu-submenu-wrap-active .ProseMirror-menu-submenu {
   display: block;
 }
 


### PR DESCRIPTION
Web accessibility is important, and we should try to make our components accessible by default. The W3C provides [an interactive example of the correct way to make an accessible toolbar](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/examples/toolbar/); this pull request tries to integrate their suggestions into this project. It does the following:

* MenuItems render as `<button>` elements by default, instead of `<div>` elements.
* All event handlers for the `mousedown` event on these buttons have changed to handle the `click` event, instead. `mousedown` only works for users that use a mouse; `click` is device-independent, and also works for keyboard-based usage.
* Appropriate ARIA roles have been added where necessary, as well as various ARIA attributes such as `aria-pressed` for active MenuItems, `aria-checked` for active items in a Dropdown, etc.
* The toolbar now uses a [roving `tabindex`](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus.
* Dropdown contents render as list elements by default; `<ol>` if `options.ordered` is set to true, `<ul>` otherwise.
* The menu can be positioned either before or after the editor in the DOM (important for sequencing tab stops), and can be set to either a horizontal or vertical orientation (important for determining which arrow keys are used to move the focus within the menu).

This is my first attempt to contribute to ProseMirror; I hope I'm doing it right! The `CONTRIBUTING.md` file mentioned running a linter using `npm run lint`, but that doesn't seem to be set up for this project.