### PR TITLE
fix tabindex for initial rendering dropdown items

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -313,6 +313,12 @@ function renderDropdownItems(items: readonly MenuElement[], view: EditorView) {
     updates.push(update)
   }
 
+  let focusIndex = findFocusableIndex(focusables, -1, 1)
+  for (let i = 0; i < focusables.length; i++) {
+    // set `tabindex` to -1 for all but the first focusable item
+    if (i != focusIndex) focusables[i].setAttribute("tabindex", "-1")
+  }
+
   function update(state: EditorState) {
     let something = false
     for (let i = 0; i < elts.length; i++) {

--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -82,11 +82,12 @@ class MenuBarView {
       potentialScrollers.forEach(el => el.addEventListener('scroll', this.scrollHandler!))
     }
 
+    let focusIndex = findFocusableIndex(this.focusables, -1, 1)
     // update focusIndex on focus change
     for (let i = 0; i < focusables.length; i++) {
       let focusable = focusables[i]
       // set `tabindex` to -1 for all but the first focusable item
-      if (i) focusable.setAttribute("tabindex", "-1")
+      if (i != focusIndex) focusable.setAttribute("tabindex", "-1")
       focusable.addEventListener("focus", () => {
         if (this.focusIndex === i) return
         let prevFocusItem = this.focusables[this.focusIndex]


### PR DESCRIPTION
When the items in a dropdown are rendered, they should _also_ have their `tabindex` set to `-1` for all items except the first focusable item.